### PR TITLE
added second outer circle and added more control how to color them

### DIFF
--- a/PositionalGuide/ConfigWindow.cs
+++ b/PositionalGuide/ConfigWindow.cs
@@ -235,9 +235,8 @@ public class ConfigWindow: Window, IDisposable {
 		changed |= ImGui.SliderScalar("Outer circle range", ImGuiDataType.U16, ptrs[4], this.minOuterCircleRangePtr, this.maxOuterCircleRangePtr, "%i", ImGuiSliderFlags.AlwaysClamp);
 		utils.Tooltip("How big should the outer circle be?"
 			+ "\n"
-			+ "\nValue is an offset to the target circle, and a value of 10 corresponds to 1 yalm in the game. So, for a value of 10, the circle is 1 yalm larger in radius compared to the target circle."
-			+ "\n"
-			+ "\nA value of 35 very closely resembles the max melee range, meaning you can e.g. auto attack when the center of the player model is inside the circle.");
+			+ "\nValue is an offset to the target circle, and a value of 10 corresponds to 1 yalm."
+			+ "\nA value of 35 very closely resembles the max melee range.");
 
 		// sliders specifically to control the tether line length
 		ImGui.PushStyleVar(ImGuiStyleVar.Alpha, tether ? 1 : InactiveOptionAlpha);
@@ -337,6 +336,8 @@ public class ConfigWindow: Window, IDisposable {
 		Marshal.FreeHGlobal(this.maxModifierPtr);
 		Marshal.FreeHGlobal(this.minThicknessPtr);
 		Marshal.FreeHGlobal(this.maxThicknessPtr);
+		Marshal.FreeHGlobal(this.minOuterCircleRangePtr);
+		Marshal.FreeHGlobal(this.maxOuterCircleRangePtr);
 		Marshal.FreeHGlobal(this.negativeOnePtr);
 		Marshal.FreeHGlobal(this.negativeTwoPtr);
 		Marshal.FreeHGlobal(this.maxTetherLengthPtr);

--- a/PositionalGuide/Configuration.cs
+++ b/PositionalGuide/Configuration.cs
@@ -17,7 +17,8 @@ public class Configuration: IPluginConfiguration {
 		IndexBackLeft = 5,
 		IndexLeft = 6,
 		IndexFrontLeft = 7,
-		IndexCircle = 8;
+		IndexCircle = 8,
+		IndexOuterCircle = 9;
 	public static readonly string[] Directions = new string[] {
 		"front guideline",
 		"front right guideline",
@@ -28,6 +29,7 @@ public class Configuration: IPluginConfiguration {
 		"left guideline",
 		"front left guideline",
 		"target circle",
+		"outer circle",
 	};
 
 	public int Version { get; set; } = 1;
@@ -40,6 +42,9 @@ public class Configuration: IPluginConfiguration {
 	public bool DrawOnSelfOnly { get; set; } = true;
 	public bool DrawTetherLine { get; set; } = false;
 	public bool FlattenTether { get; set; } = false;
+	public bool AlwaysUseCircleColours { get; set; } = false;
+	public bool AlwaysUseCircleColoursTarget { get; set; } = false;
+	public bool AlwaysUseCircleColoursOuter { get; set; } = false;
 
 	/// <summary>
 	/// Starts at front then goes clockwise up to index=7, then circle at index=8
@@ -54,20 +59,21 @@ public class Configuration: IPluginConfiguration {
 		false, // left
 		false, // front left
 		false, // circle
+		false, // outer circle
 	};
 
 	public short ExtraDrawRange { get; set; } = 0;
 	public short MinDrawRange { get; set; } = 0;
 	public short MaxDrawRange { get; set; } = byte.MaxValue;
 	public short LineThickness { get; set; } = 3;
-
+	public short OuterCircleRange { get; set; } = 35;
 	public short TetherLengthInner { get; set; } = -1; // if -1, go to centre of target's hitbox
 	public short TetherLengthOuter { get; set; } = -1; // if -1, go to CENTRE of player's hitbox; if -2, go to EDGE of player's hitbox
 
 	public Vector4 TetherColour { get; set; } = new(1);
 
 	/// <summary>
-	/// Starts at front then goes clockwise up to index=7, then circle at index=8
+	/// Starts at front then goes clockwise up to index=7, then circle at index=8 and outer circle at index=9
 	/// </summary>
 	public Vector4[] LineColours { get; set; } = new Vector4[] {
 		new Vector4(1, 0, 0, 1), // front
@@ -79,21 +85,37 @@ public class Configuration: IPluginConfiguration {
 		new Vector4(0, 0, 1, 1), // left
 		new Vector4(1, 0, 0, 1), // front left
 		new Vector4(1, 1, 0, 1), // circle default
+		new Vector4(1, 1, 0, 1), // outer circle default
 	};
 
 	public void Update() {
-
-		if (this.DrawGuides.Length < 9) {
-			bool[] guides = new bool[9];
+		int initalLength = this.DrawGuides.Length;
+		if (initalLength < 10) {
+			bool[] guides = new bool[10];
 			Array.Copy(this.DrawGuides, guides, this.DrawGuides.Length);
-			guides[8] = false;
+			
+			if (initalLength < 9) {
+				guides[8] = false;
+			}
+			if (initalLength < 10) {
+				guides[9] = false; 
+			}
+
 			this.DrawGuides = guides;
 		}
 
-		if (this.LineColours.Length < 9) {
-			Vector4[] colours = new Vector4[9];
+		initalLength = this.LineColours.Length;
+		if (initalLength < 10) {
+			Vector4[] colours = new Vector4[10];
 			Array.Copy(this.LineColours, colours, this.LineColours.Length);
-			colours[8] = new Vector4(1, 1, 0, 1);
+			
+			if (initalLength < 9) {
+				colours[8] = new Vector4(1, 1, 0, 1);
+			}
+			if (initalLength < 10) {
+				colours[9] = new Vector4(1, 1, 0, 1);
+			}
+
 			this.LineColours = colours;
 		}
 
@@ -148,6 +170,12 @@ public class Configuration: IPluginConfiguration {
 	}
 
 	[JsonIgnore]
+	public bool DrawOuterCircle {
+		get => this.DrawGuides[IndexOuterCircle];
+		set => this.DrawGuides[IndexOuterCircle] = value;
+	}
+
+	[JsonIgnore]
 	public float SoftDrawRange => (float)this.ExtraDrawRange / 10;
 
 	[JsonIgnore]
@@ -161,5 +189,8 @@ public class Configuration: IPluginConfiguration {
 
 	[JsonIgnore]
 	public float SoftOuterTetherLength => (float)this.TetherLengthOuter / 10;
+
+	[JsonIgnore]
+	public float SoftOuterCircleRange => (float)this.OuterCircleRange / 10;
 	#endregion
 }

--- a/PositionalGuide/PositionalGuide.csproj
+++ b/PositionalGuide/PositionalGuide.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Product>PositionalGuide</Product>
-		<Version>4.1.0</Version>
+		<Version>4.2.0</Version>
 		<Description>Provides drawn guidelines to see where you need to stand to hit enemies with positionals</Description>
 		<Copyright>Copyleft VariableVixen 2022</Copyright>
 		<PackageProjectUrl>https://github.com/PrincessRTFM/PositionalAssistant</PackageProjectUrl>


### PR DESCRIPTION
No idea if this goes beyond the idea of this plugin. I initially wrote this for me with the main intention to get a better feeling and visual representation what my melee range is. So I added a second outer circle (changeable in size) and also added the option to decouple the color of the circles from the guidelines.

I tested config compatibility and for me it seemed to work going from the current config version to a new one, also tried simulating with even older config without the target circle.

I had to extract the circle drawing into a function which has quite a lot arguments now. Not really happy about it but did not see a good alternative without reworking more parts, which I wanted to avoid.
