### PR TITLE
add server info bar (DTR) entry to quickly enable and disable rendering

### DIFF
--- a/PositionalGuide/ConfigWindow.cs
+++ b/PositionalGuide/ConfigWindow.cs
@@ -34,6 +34,8 @@ public class ConfigWindow: Window, IDisposable {
 	private bool disposed;
 
 	private readonly Configuration conf;
+	public delegate void SettingsUpdate();
+	public event SettingsUpdate? OnSettingsUpdate;
 
 	public ConfigWindow(Plugin core) : base(core.Name, flags) {
 		this.RespectCloseHotkey = true;
@@ -313,6 +315,7 @@ public class ConfigWindow: Window, IDisposable {
 			this.conf.DrawGuides = drawing;
 			this.conf.LineColours = colours;
 			Plugin.Interface.SavePluginConfig(this.conf);
+			this.OnSettingsUpdate?.Invoke();
 		}
 
 		for (int i = 0; i < ptrs.Length; ++i)

--- a/PositionalGuide/PositionalGuide.csproj
+++ b/PositionalGuide/PositionalGuide.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Product>PositionalGuide</Product>
-		<Version>4.2.0</Version>
+		<Version>4.3.0</Version>
 		<Description>Provides drawn guidelines to see where you need to stand to hit enemies with positionals</Description>
 		<Copyright>Copyleft VariableVixen 2022</Copyright>
 		<PackageProjectUrl>https://github.com/PrincessRTFM/PositionalAssistant</PackageProjectUrl>


### PR DESCRIPTION
Added a clickable DTR entry which toggles the Config.Enabled and displays the state as On, Off in the bar. Most of the DTR stuff is based on what I saw other plugins do.

Decided on having the `Plugin` class to be the common place to handle the DTR. It is a bit of a design decision where to put it but I think `Plugin` is the best place currently. Added a simple callback functionality to the `ConfigWindow` so other modules can be notified if a change happened, in this case only used by `Plugin`. Quite barebones right now but offers the possibility to extend on it in the future if needed.

I did not introduce a new config setting enabling, disabling the DTR, since this can be done in the overall Dalamud settings already. Also a design decision, some plugins do it, some don't. I do not see the point in cluttering your own settings and code when the functionality is already there in the overall settings.

I tested setting the flag via the DTR entry, the settings menu and `/posguide toggle render`, to see if they all sync up and work.