### PR TITLE
rework circle rendering

### DIFF
--- a/PositionalGuide/PositionalGuide.csproj
+++ b/PositionalGuide/PositionalGuide.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Product>PositionalGuide</Product>
-		<Version>4.3.0</Version>
+		<Version>4.3.1</Version>
 		<Description>Provides drawn guidelines to see where you need to stand to hit enemies with positionals</Description>
 		<Copyright>Copyleft VariableVixen 2022</Copyright>
 		<PackageProjectUrl>https://github.com/PrincessRTFM/PositionalAssistant</PackageProjectUrl>


### PR DESCRIPTION
I am still cleaning up a bit and testing it but wanted it to share already to get some feedback for the design and general review comments.

I decoupled the rendering of circles and guidelines as much as possible. Generally the only problem is the colouring of the circle. I solved this now by creating a lookup table using the angles of the guidelines and the circle segments. Using the color of the closest (in terms of angle distance) active guideline for the circle segment.

Calculating this lookup table has to be done at the start and on every setting change. In theory one could only recompute it on specific setting changes, but did not do it for now since this is a more complex change and calculating the lookup table does not take too long.

Visible effect is that now the circle is rendered without gaps. Also line segments also disappear bit for bit when going off screen and not an entire arc at once.

Also even if draw times were quite low before (under 0.1ms for me) it is now even faster by around 20-30%.

The circle segment count could be made configurable in theory now, it is hardcoded currently to match the segment count from before.